### PR TITLE
Feature/use content length headers

### DIFF
--- a/src/Res.re
+++ b/src/Res.re
@@ -21,7 +21,7 @@ let status = (status: int, res: t) => {
 };
 
 let raw = (req: Req.t('a), body: string, res: t) => {
-  let resWithHeaders = addHeader(("Connection", "close"), res);
+  let resWithHeaders = addHeader(("Content-length", String.length(body) |> string_of_int), res);
   let response = createResponse(resWithHeaders);
   let requestDescriptor = Req.reqd(req);
 

--- a/src/Res.rei
+++ b/src/Res.rei
@@ -12,7 +12,7 @@ let status: (int, t) => t;
 
 /**
  Sends response [t] with body [string].
- Adding headers [Content-type: application/json] and [Connection: close]
+ Adding headers [Content-type: application/json] and [Content-length]
 
  {e This function will end the http request/response lifecycle.}
  */
@@ -20,7 +20,7 @@ let json: (Req.t('sessionData), string, t) => Lwt.t(unit);
 
 /**
  Sends response [t] with body [string].
- Adding headers [Content-type: text/html] and [Connection: close]
+ Adding headers [Content-type: text/html] and [Content-length]
 
  {e This function will end the http request/response lifecycle.}
  */
@@ -28,7 +28,7 @@ let html: (Req.t('sessionData), string, t) => Lwt.t(unit);
 
 /**
  Sends response [t] with body [string].
- Adding headers [Content-type: text/plain] and [Connection: close]
+ Adding headers [Content-type: text/plain] and [Content-length]
 
  {e This function will end the http request/response lifecycle.}
  */
@@ -37,7 +37,7 @@ let text: (Req.t('sessionData), string, t) => Lwt.t(unit);
 /**
  Sends response [t] with body [string].
 
- {e This function will not add any headers other than [Connection: close].}
+ {e This function will not add any headers other than [Content-length] with the length of [string].}
  {e This function will end the http request/response lifecycle.}
  */
 let raw: (Req.t('sessionData), string, t) => Lwt.t(unit);


### PR DESCRIPTION
Fixes #28 

- Uses `Content-length` headers for all built in `Res` functions.  This improves performance!