### PR TITLE
Feature/better session config

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,20 @@ In the case above `/static/images/icon.png` would be served from `$cur__root/pub
 ### Session Data
 Many `Naboris` types take the parameter `'sessionData` this represents a custom data type that will define session data that will be attached to an incoming request.
 
+#### sessionConfig
+__Naboris.ServerConfig.setSessionConfig__ will return a new server configuration with the desired
+session configuration. This call consists of one required argument `sessionGetter` and two
+optional arguments `~maxAge` and `~sidKey`.
+
+```reason
+let setSessionConfig: (~maxAge: int=?, ~sidKey: string=?, option(string) => Lwt.t(option(Session.t('sessionData))), ServerConfig.t('sessionData)) => ServerConfig.t('sessionData);
+```
+```ocaml
+val setSessionConfig: ?maxAge: int -> ?sidKey: string -> string option -> 'sessionData Session.t option Lwt.t -> 'sessionData ServerConfig.t -> 'sessionData ServerConfig.t
+```
+
 #### sessionGetter
-__Naboris.ServerConfig.setSessionGetter__ will set the configuration with a function with the signature `option(string) => Lwt.t(option(Naboris.Session.t('sessionData)))`.  That's a complicated type signature that expresses that the request may or may not have a `sessionId`; and given that fact it may or may not return a session.
+A special function that is used to set session data on an incoming reuquest based on the requests cookies. The signature looks like: `option(string) => Lwt.t(option(Naboris.Session.t('sessionData)))`.  That's a complicated type signature that expresses that the request may or may not have a `sessionId`; and given that fact it may or may not return a session.
 ```reason
 // ReasonML
 // Your custom data type
@@ -332,7 +344,7 @@ type userData = {
 };
 
 let serverConfig: Naboris.ServerConfig(userData) = Naboris.ServerConfig.create()
-  |> Naboris.ServerConfig.setSessionGetter(sessionId => switch(sessionId) {
+  |> Naboris.ServerConfig.setSessionConfig(sessionId => switch(sessionId) {
     | Some(id) =>
       /* for the sake of this example we're not using ppx or infix */
       /* lwt promises can be made much easier to read by using these */
@@ -383,7 +395,7 @@ type user_data = {
 }
 
 let serverConfig: user_data Naboris.ServerConfiguserData = Naboris.ServerConfig.create ()
-  |> Naboris.ServerConfig.setSessionGetter (fun session_id ->
+  |> Naboris.ServerConfig.setSessionConfig (fun session_id ->
     match (session_id) with
       | Some(id) =>
         (* for the sake of this example we're not using ppx or infix *)
@@ -417,6 +429,10 @@ let serverConfig: user_data Naboris.ServerConfiguserData = Naboris.ServerConfig.
           Naboris.Res.status 200 res
             |> Naboris.Res.text req user_data.username)
 ```
+
+#### sidKey and maxAge
+`sidKey` - `string` (optional) - The key used to store the session id in browser cookies. Defaults to `"nab.sid"`.
+`maxAge` - `int` (optional) - The max age of session cookies in seconds.  Defaults to `2592000` (30 days.)
 
 ## Advanced
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ let _ = Lwt_main.run(Naboris.listenAndWaitForever 3000 server_config)
 (* In a browser navigate to http://localhost:3000/hello *)
 ```
 
+> Pre `1.0.0` the API may be changing a bit. A list of these changes will be kept below.
+
 ## Contents
 * [Getting Started](#getting-started)
     * [Installation](#installation)
@@ -53,6 +55,7 @@ let _ = Lwt_main.run(Naboris.listenAndWaitForever 3000 server_config)
 * [Advanced](#advanced)
 	* [Middlewares](#middlewares)
 * [Development](#development)
+* [Breaking Changes](#breaking-changes)
 
 ```
                                                            
@@ -320,7 +323,7 @@ Many `Naboris` types take the parameter `'sessionData` this represents a custom 
 
 #### sessionConfig
 __Naboris.ServerConfig.setSessionConfig__ will return a new server configuration with the desired
-session configuration. This call consists of one required argument `sessionGetter` and two
+session configuration. This call consists of one required argument `mapSession` and two
 optional arguments `~maxAge` and `~sidKey`.
 
 ```reason
@@ -330,7 +333,7 @@ let setSessionConfig: (~maxAge: int=?, ~sidKey: string=?, option(string) => Lwt.
 val setSessionConfig: ?maxAge: int -> ?sidKey: string -> string option -> 'sessionData Session.t option Lwt.t -> 'sessionData ServerConfig.t -> 'sessionData ServerConfig.t
 ```
 
-#### sessionGetter
+#### mapSession
 A special function that is used to set session data on an incoming reuquest based on the requests cookies. The signature looks like: `option(string) => Lwt.t(option(Naboris.Session.t('sessionData)))`.  That's a complicated type signature that expresses that the request may or may not have a `sessionId`; and given that fact it may or may not return a session.
 ```reason
 // ReasonML
@@ -485,3 +488,9 @@ esy install
 npm run test
 ```
 [docs html index]: https://shawn-mcginty.github.io/naboris/docs/html/index.html
+
+## Breaking Changes
+
+| From | To | Breaking Change |
+| --- | --- | --- |
+| `0.1.0` | `0.1.1` | `ServerConfig.setSessionGetter` changed to `ServerConfig.setSessionConfig` which also allows `~maxAge` and `~sidKey` to be passed in optionally. |

--- a/src/Naboris.re
+++ b/src/Naboris.re
@@ -10,6 +10,7 @@ module Session = Session;
 module SessionManager = SessionManager;
 module Cookie = Cookie;
 module ServerConfig = ServerConfig;
+module SessionConfig = SessionConfig;
 
 open Lwt.Infix;
 

--- a/src/Naboris.rei
+++ b/src/Naboris.rei
@@ -55,3 +55,6 @@
 
   /** {b Less commonly used.} */
   module Router = Router;
+
+  /** {b Less commonly used.} */
+  module SessionConfig = SessionConfig;

--- a/src/Req.re
+++ b/src/Req.re
@@ -1,6 +1,8 @@
 type t('sessionData) = {
   requestDescriptor: Httpaf.Reqd.t,
   session: option(Session.t('sessionData)),
+  sidKey: string,
+  maxAge: int,
 };
 
 let reqd = req => req.requestDescriptor;
@@ -26,8 +28,10 @@ let getBody = ({requestDescriptor, _}) => {
   Lwt_stream.fold((a, b) => a ++ b, bodyStream, "");
 };
 
-let fromReqd = reqd => {
-  let defaultReq = {requestDescriptor: reqd, session: None};
+let fromReqd = (reqd, sessionConfig) => {
+  let sidKey = SessionConfig.sidKey(sessionConfig);
+  let maxAge = SessionConfig.maxAge(sessionConfig);
+  let defaultReq = {requestDescriptor: reqd, session: None, sidKey, maxAge};
   defaultReq;
 };
 
@@ -41,3 +45,7 @@ let getSessionData = req => {
 let setSessionData = (maybeSession, req) => {
   {...req, session: maybeSession};
 };
+
+let sidKey = req => req.sidKey;
+
+let maxAge = req => req.maxAge;

--- a/src/Req.rei
+++ b/src/Req.rei
@@ -33,4 +33,14 @@ let setSessionData: (option(Session.t('sessionData)), t('sessionData)) => t('ses
  {b Intended for internal use.}
  Creates default req record.
  */
-let fromReqd: Httpaf.Reqd.t => t('sessionData);
+let fromReqd: (Httpaf.Reqd.t, option(SessionConfig.t('sessionData))) => t('sessionData);
+
+/**
+ Get key for session id cookie
+ */
+let sidKey: t('sessionData) => string;
+
+/**
+ Get max age for session id cookies (in seconds)
+ */
+let maxAge: t('sessionData) => int;

--- a/src/Res.re
+++ b/src/Res.re
@@ -98,15 +98,14 @@ let static = (basePath, pathList, req: Req.t('a), res) => {
     });
 };
 
-let setSessionCookies = (newSessionId, res) => {
+let setSessionCookies = (newSessionId, sessionIdKey, maxAge, res) => {
   let setCookieKey = "Set-Cookie";
-  let thirtyDays = string_of_int(30 * 24 * 60 * 60);
-  let sessionIdKey = "nab.sid";
+  let maxAgeStr = string_of_int(maxAge);
 
   addHeader(
     (
       setCookieKey,
-      sessionIdKey ++ "=" ++ newSessionId ++ "; Max-Age=" ++ thirtyDays ++ ";",
+      sessionIdKey ++ "=" ++ newSessionId ++ "; Max-Age=" ++ maxAgeStr ++ ";",
     ),
     res,
   );

--- a/src/Res.rei
+++ b/src/Res.rei
@@ -70,10 +70,11 @@ let redirect: (string, Req.t('sessionData), t) => Lwt.t(unit);
 let reportError: (Req.t('sessionData), exn) => unit;
 
 /**
- Adds [Set-Cookie] header to response [t] with sessionId [string] as a value.
- Uses ["nab.sid"] as the key for parsing the cookie later.
- Uses 30 days [Max-Age] for expiration.
+ Adds [Set-Cookie] header to response [t] with
+ [string] sessionId
+ [string] cookie key
+ [int] max age of cookie in seconds
 
  {e These will be configurable in future versions.}
  */
-let setSessionCookies: (string, t) => t;
+let setSessionCookies: (string, string, int, t) => t;

--- a/src/Server.re
+++ b/src/Server.re
@@ -13,7 +13,7 @@ let buildConnectionHandler = (serverConfig: ServerConfig.t('sessionData)) => {
     let route = Router.generateRoute(target, meth);
 
     Lwt.async(() => {
-      let rawReq = Req.fromReqd(request_descriptor);
+      let rawReq = Req.fromReqd(request_descriptor, ServerConfig.sessionConfig(serverConfig));
 
       SessionManager.resumeSession(serverConfig, rawReq)
       >>= (

--- a/src/ServerConfig.re
+++ b/src/ServerConfig.re
@@ -1,7 +1,3 @@
-type sessionConfig('sessionData) = {
-  getSession: option(string) => Lwt.t(option(Session.t('sessionData))),
-};
-
 type httpAfConfig = {
   read_buffer_size: int,
   request_body_buffer_size: int,
@@ -12,7 +8,7 @@ type httpAfConfig = {
 type t('sessionData) = {
   onListen: unit => unit,
   routeRequest: (Route.t, Req.t('sessionData), Res.t) => Lwt.t(unit),
-  sessionConfig: option(sessionConfig('sessionData)),
+  sessionConfig: option(SessionConfig.t('sessionData)),
   errorHandler: option(ErrorHandler.t),
   httpAfConfig: option(httpAfConfig),
   middlewares: list(Middleware.t('sessionData))
@@ -86,9 +82,11 @@ let addStaticMiddleware = (pathPrefix, publicPath, conf) => conf
     | _ => next(route, req, res)
   });
 
-let setSessionGetter = (getSessionFn, conf) => {
-  let sessionConfig = {
+let setSessionConfig = (~maxAge=2592000, ~sidKey="nab.sid", getSessionFn, conf) => {
+  let sessionConfig: SessionConfig.t('sessionData) = {
     getSession: getSessionFn,
+    maxAge,
+    sidKey,
   };
   { ...conf, sessionConfig: Some(sessionConfig) };
 };

--- a/src/ServerConfig.rei
+++ b/src/ServerConfig.rei
@@ -20,9 +20,9 @@ let create: unit => t('sessionData);
 let setOnListen: (unit => unit, t('sessionData)) => t('sessionData);
 
 /**
- Creates new config from [t('sessionData)] with sessionGetter function [option(string) => Lwt.t(option(Session.t('sessionData)))].
+ Creates new config from [t('sessionData)] with mapSession function [option(string) => Lwt.t(option(Session.t('sessionData)))].
 
- [sessionGetter] function is called at the very beginning of each request/response lifecycle.
+ [mapSession] function is called at the very beginning of each request/response lifecycle.
  Used to set session data into the [Req.t('sessionData)] for use later in the request/response lifecycle.
 
  [~maxAge] Optional param to set max age for session cookies in seconds (defaults to 30 days)

--- a/src/ServerConfig.rei
+++ b/src/ServerConfig.rei
@@ -1,9 +1,5 @@
 type t('sessionData);
 
-type sessionConfig('sessionData) = {
-  getSession: option(string) => Lwt.t(option(Session.t('sessionData))),
-};
-
 type httpAfConfig = {
   read_buffer_size: int,
   request_body_buffer_size: int,
@@ -28,8 +24,11 @@ let setOnListen: (unit => unit, t('sessionData)) => t('sessionData);
 
  [sessionGetter] function is called at the very beginning of each request/response lifecycle.
  Used to set session data into the [Req.t('sessionData)] for use later in the request/response lifecycle.
+
+ [~maxAge] Optional param to set max age for session cookies in seconds (defaults to 30 days)
+ [~sidKey] Optional param to set key for session cookies (defaults to ["nab.sid"])
  */
-let setSessionGetter: (option(string) => Lwt.t(option(Session.t('sessionData))), t('sessionData)) => t('sessionData);
+let setSessionConfig: (~maxAge: int=?, ~sidKey: string=?, option(string) => Lwt.t(option(Session.t('sessionData))), t('sessionData)) => t('sessionData);
 
 /**
  Creates new config from [t('sessionData)] with requestHandler [(Route.t, Req.t('sessionData), Res.t) => Lwt.t(unit)].
@@ -64,10 +63,10 @@ let addMiddleware: (Middleware.t('sessionData), t('sessionData)) => t('sessionDa
 let addStaticMiddleware: (list(string), string, t('sessionData)) => t('sessionData);
 
 /**
- Returns [sessionConfig('sessionData)] from config.
+ Returns [SessionConfig.t('sessionData)] from config.
  [None] if none is configured.
  */
-let sessionConfig: t('sessionData) => option(sessionConfig('sessionData));
+let sessionConfig: t('sessionData) => option(SessionConfig.t('sessionData));
 
 /**
  Returns list of middlewares from the config.

--- a/src/SessionConfig.re
+++ b/src/SessionConfig.re
@@ -1,0 +1,15 @@
+type t('sessionData) = {
+  getSession: option(string) => Lwt.t(option(Session.t('sessionData))),
+  sidKey: string,
+  maxAge: int,
+};
+
+let maxAge = conf => switch(conf) {
+  | Some(sessConf) => sessConf.maxAge
+  | _ => 2592000
+};
+
+let sidKey = conf => switch(conf) {
+  | Some(sessConf) => sessConf.sidKey
+  | _ => "nab.sid"
+};

--- a/src/SessionConfig.rei
+++ b/src/SessionConfig.rei
@@ -1,0 +1,15 @@
+type t('sessionData) = {
+  getSession: option(string) => Lwt.t(option(Session.t('sessionData))),
+  sidKey: string,
+  maxAge: int,
+};
+
+/**
+ Returns key to be used for session cookies.
+ */
+let sidKey: option(t('sessionData)) => string;
+
+/**
+ Returns max age to be used for session cookies.
+ */
+let maxAge: option(t('sessionData)) => int;

--- a/src/SessionManager.re
+++ b/src/SessionManager.re
@@ -11,7 +11,7 @@ let startSession = (req, res, data) => {
   let newSessionId = hash1 ++ hash2 ++ hash3 ++ hash4;
 
   let req2 = Req.setSessionData(Some(Session.create(newSessionId, data)), req);
-  let res2 = Res.setSessionCookies(newSessionId, res);
+  let res2 = Res.setSessionCookies(newSessionId, Req.sidKey(req2), Req.maxAge(req2), res);
   (req2, res2, newSessionId);
 };
 

--- a/src/SessionManager.rei
+++ b/src/SessionManager.rei
@@ -8,7 +8,7 @@ let startSession: (Req.t('sessionData), Res.t, 'sessionData) => (Req.t('sessionD
 /**
  {b Intended for internal use.}
 
- Applies [sessionGetter] from config to request which uses the session id from the request cookies.
+ Applies [mapSession] from config to request which uses the session id from the request cookies.
  Returns promise of a new request with session data available if it was found.
  */
 let resumeSession: (ServerConfig.t('sessionData), Req.t('sessionData)) => Lwt.t(Req.t('sessionData));

--- a/src/utils/Cookie.re
+++ b/src/utils/Cookie.re
@@ -1,5 +1,5 @@
-let rec getSessionId = cookieStr => {
-  let sessionKey = "nab.sid=";
+let rec getSessionId = (sidKey, cookieStr) => {
+  let sessionKey = sidKey ++ "=";
   let cookieLength = String.length(cookieStr);
   let keyLength = String.length(sessionKey);
   let startOfString = 0;
@@ -20,7 +20,7 @@ let rec getSessionId = cookieStr => {
         Some(String.sub(partialCookie, startOfString, endOfCookie))
       };
     } else {
-      getSessionId(String.sub(cookieStr, i + 1, cookieLength - (i + 1)));
+      getSessionId(sidKey, String.sub(cookieStr, i + 1, cookieLength - (i + 1)));
     };
   };
 };
@@ -28,6 +28,6 @@ let rec getSessionId = cookieStr => {
 let sessionIdOfReq = req => {
   switch (Req.getHeader("Cookie", req)) {
   | None => None
-  | Some(header) => getSessionId(header)
+  | Some(header) => getSessionId(Req.sidKey(req), header)
   };
 };

--- a/src/utils/Cookie.rei
+++ b/src/utils/Cookie.rei
@@ -1,7 +1,7 @@
 /**
- Given a Cookie header string value extracts sessonId
+ Given the session id key and cookie header string values extracts sessonId
  */
-let getSessionId: string => option(string);
+let getSessionId: (string, string) => option(string);
 
 /**
  Extract sessionId from http cookie headers in [Req.t]

--- a/test/utils/CookieTest.re
+++ b/test/utils/CookieTest.re
@@ -12,7 +12,7 @@ let testSuite = () => (
           check(
             option(string),
             "same sid",
-            Naboris.Cookie.getSessionId(cookieStr),
+            Naboris.Cookie.getSessionId("nab.sid", cookieStr),
             Some(expectedSid),
           )
         );
@@ -23,7 +23,7 @@ let testSuite = () => (
       `Quick,
       _ => {
         let cookieStr = "nnect.sid=s%3AadVKe5fVEcZVq4X5ZUrMen2U88jmjy4f.LOwere3akcgCno7WDqinHgL%2BXWXVp2SgbHZzv7%2Btbt4";
-        let maybeCookie = Naboris.Cookie.getSessionId(cookieStr);
+        let maybeCookie = Naboris.Cookie.getSessionId("nab.sid", cookieStr);
         Alcotest.(
           check(option(string), "no matching cookie", None, maybeCookie)
         );
@@ -39,7 +39,7 @@ let testSuite = () => (
           check(
             option(string),
             "same sid",
-            Naboris.Cookie.getSessionId(cookieStr),
+            Naboris.Cookie.getSessionId("nab.sid", cookieStr),
             Some(expectedSid),
           )
         );
@@ -54,7 +54,7 @@ let testSuite = () => (
           check(
             option(string),
             "empty",
-            Naboris.Cookie.getSessionId(cookieStr),
+            Naboris.Cookie.getSessionId("nab.sid", cookieStr),
             None,
           )
         );


### PR DESCRIPTION
Fixes #23 

- Changes `ServerConfig.setSessionGetter` to `ServerConfig.setSessionConfig` which allows for optional args `~maxAge` and `~sidKey`.  Also all references to `sessionGetter` were changed to `mapSession`