### PR TITLE
Fixes #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,3 +574,4 @@ npm run test
 | --- | --- | --- |
 | `0.1.0` | `0.1.1` | `ServerConfig.setSessionGetter` changed to `ServerConfig.setSessionConfig` which also allows `~maxAge` and `~sidKey` to be passed in optionally. |
 | `0.1.0` | `0.1.1` | All `RequestHandler.t` and `Middleware.t` now return `Lwt.t(Res.t)` instead of `Lwt.t(unit)` |
+| `0.1.0` | `0.1.1` | `Res.reportError` now taxes `exn` as the first argument to match more closely the rest of the `Res` API. |

--- a/src/Res.re
+++ b/src/Res.re
@@ -137,7 +137,7 @@ let redirect = (path, req, res) => {
   status(302, res) |> addHeader(("Location", path)) |> text(req, "Found");
 };
 
-let reportError = (req: Req.t('a), res, exn) => {
+let reportError = (exn, req: Req.t('a), res) => {
   Httpaf.Reqd.report_exn(Req.reqd(req), exn);
   Lwt.return @@ closeResponse({...res, exn: Some(exn)});
 };

--- a/src/Res.rei
+++ b/src/Res.rei
@@ -75,7 +75,7 @@ let redirect: (string, Req.t('sessionData), t) => Lwt.t(t);
 /**
  Report an error [exn] to Httpaf.
  */
-let reportError: (Req.t('sessionData), t, exn) => Lwt.t(t);
+let reportError: (exn, Req.t('sessionData), t) => Lwt.t(t);
 
 /**
  Adds [Set-Cookie] header to response [t] with

--- a/test/integration-test/IntegrationTest.re
+++ b/test/integration-test/IntegrationTest.re
@@ -124,7 +124,7 @@ let startServers = lwtSwitch => {
           >>= (() => Lwt_io.close(ch)));
         return;
       | (GET, ["error", "boys"]) =>
-        Naboris.Res.reportError(req, res, SomebodyGoofed("Problems"));
+        Naboris.Res.reportError(SomebodyGoofed("Problems"), req, res);
       | _ =>
         Naboris.Res.status(404, res)
         |> Naboris.Res.html(


### PR DESCRIPTION
* `Res.reportError` now taxes `exn` as the first argument to match more closely the rest of the `Res` API.